### PR TITLE
readme: use python3 for the simple web server command

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ When you are happy with the style you are created, go to *Save* in the top bar a
 Create an index.html in your Codespace and paste the contents of the HTML file that was downloaded. Next, launch a simple web server and expose it to the internet like before.
 
 ```
-python -m http.server 1234
+python3 -m http.server 1234
 ```
 
 If everything went well, you will have created your own basemap and deployed it in under one hour!


### PR DESCRIPTION
First, apologies: I opened this before noticing #9, which makes the same one-line change. That is my mistake for not checking the open PRs first.

I would still like to offer this one with a full description, since #9 currently has no explanation and has not been reviewed yet, and the reasoning may help a maintainer merge one of the two.

The problem: step 4 tells participants to run `python -m http.server 1234`, but the dev container image has no `python`, only `python3`. Ubuntu 25.10 does not create a `python` symlink, so the command as written fails with `python: not found` and the final "serve your map" step does not work.

The fix is a single character: `python3 -m http.server 1234`.

Verified by running the whole workshop against the container image (`ghcr.io/maplibre/workshop`): `python` is not found, and `python3 -m http.server 1234` serves the exported page.

I am happy to close this in favor of #9 if you prefer. I mainly wanted the reasoning written down somewhere.
