### PR TITLE
readme: locate the workshop area in maputnik before swapping the source

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,14 @@ Look at the Web UI, especially the catalog.
 
 * Go to [Maputnik](https://maplibre.org/maputnik)
 * click open and open the `OSM Liberty` style
+* Use the search box in the top bar to find the workshop location and move the map there first, so the map is already looking at the area your tiles cover. This makes the next step obvious: the moment you swap in your own source, you will see the map change in place.
 * Use the data source editor to **modify** the existing active source `#openmaptiles`. Use the URL of your Martin instance with the `/workshop` TileJSON endpoint from the previous step.  You can get this link by clicking the `inspect` button in the data source editor, and click `Copy link` next to the `TileJSON URL`. It should look something like `https://{public URL for your Martin instance}/workshop`.
 
 ![edit datasource](assets/datasource.png)
 
 * Click the `x` button next to the `Sources` to close the data source editor.
 
-* Note that we only have detailed tiles for a small area due to the OSM extract that we used. Try to zoom out, and re-zoom in on the workshop's location to see details. To generate vector tiles for the entire world would require a somewhat more powerful server than the one that GitHub Codespaces offers.
+* Note that we only have detailed tiles for a small area due to the OSM extract that we used. Because you already moved the map to the workshop location, your data should appear right away; if you pan or zoom far outside that area the map will look empty. To generate vector tiles for the entire world would require a somewhat more powerful server than the one that GitHub Codespaces offers.
 
 * You can switch from the 'Map' view to the 'Inspect' view to see the data contained in your tiles. If it looks something like this, you are doing great so far!
 


### PR DESCRIPTION
---

While going through the workshop end to end, I hit a small point of confusion in step 3 and would like to propose a wording change.

After opening the `OSM OpenMapTiles` style and swapping the active source to my own Martin instance, the map did not appear to change: it stayed on whatever area it was already showing. Maputnik centers the map on the style, not on the source you just edited, so if you are looking at the default view when you swap the source, nothing obvious happens and it is easy to think the step failed.

Navigating to the workshop location first makes the swap unmistakable. Maputnik has a search box in the top bar, so if you find the workshop location and move the map there before editing the source, the moment you point the source at your own tiles you see the map change in place. That "it is my data now" moment is a nice payoff for participants.

This PR adds that one step before the source edit, and rewords the follow-up note that used to say "zoom out and re-zoom in to see details" (that advice no longer fits once you have already moved to the area).

Verified by running the workshop myself against a local Martin.
