### PR TITLE
readme: open the OSM Liberty style instead of OSM OpenMapTiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Look at the Web UI, especially the catalog.
 ## 3. Styling your map
 
 * Go to [Maputnik](https://maplibre.org/maputnik)
-* click open and open the `OSM OpenMapTiles` style
+* click open and open the `OSM Liberty` style
 * Use the data source editor to **modify** the existing active source `#openmaptiles`. Use the URL of your Martin instance with the `/workshop` TileJSON endpoint from the previous step.  You can get this link by clicking the `inspect` button in the data source editor, and click `Copy link` next to the `TileJSON URL`. It should look something like `https://{public URL for your Martin instance}/workshop`.
 
 ![edit datasource](assets/datasource.png)


### PR DESCRIPTION
Fixes #12.

This changes the style recommended in step 3 from `OSM OpenMapTiles` to `OSM Liberty`.

Why: `OSM OpenMapTiles` pulls its glyphs from api.maptiler.com with the shared demo key, which is restricted by HTTP Referer to maplibre.org. It renders fine inside Maputnik, but once you Create HTML and serve the page from your own origin (the Codespace forwarded port, localhost) the glyph requests return 403 and labels fall back to the browser default font. `OSM Liberty` uses key-free glyphs (orangemug.github.io) and sprite (maputnik.github.io), so the exported map keeps the intended fonts on any origin, and it also ships a 3D building layer that pairs nicely with the render_height attribute Planetiler already produces.

The rest of step 3 is unchanged: OSM Liberty has the same `openmaptiles` source, so repointing `#openmaptiles` to your Martin instance still applies. Verified end to end on a fresh browser against a Codespace (Japanese and Latin labels, POI icons, and 3D buildings all render).

One question before merging: if `OSM OpenMapTiles` was chosen deliberately, I would like to understand why. Since Planetiler produces OpenMapTiles-schema tiles, picking an OpenMapTiles-named style is a reasonable thematic fit and I may be missing a reason. Happy to adjust or drop this if so.
